### PR TITLE
hot fix for extraneous newline issue; add envset p008.

### DIFF
--- a/bin/museSetup.sh
+++ b/bin/museSetup.sh
@@ -366,7 +366,7 @@ else
     TEMP=$MUSE_ENVSET_DIR/linkOrder
 fi
 # end up with a list of words like: Tutorial Offline
-export MUSE_LINK_ORDER=$(cat $TEMP | sed 's/#.*$//' )
+export MUSE_LINK_ORDER=$(cat $TEMP | awk 'substr($0,0,1) != "#" {print}' | sed 's/#.*$//' )
 
 
 # list of local muse packages


### PR DESCRIPTION
When defining MUSE_LINK_ORDER, strip comments from the linkOrder file - see commit comment for more details.

A previous untagged commit added envset p008.  This PR brings that in too.

