### PR TITLE
small improvements to procedures and messages

### DIFF
--- a/bin/museBuild.sh
+++ b/bin/museBuild.sh
@@ -36,8 +36,22 @@ fi
 cd $MUSE_WORK_DIR
 
 mkdir -p $MUSE_BUILD_DIR
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "ERROR - could not execute: mkdir -p $MUSE_BUILD_DIR"
+    exit $RC
+fi
 echo -n "$(date +'%D %H:%M:%S to ')" > $MUSE_BUILD_DIR/.musebuild
 
+#
+# make a repo directory in the build area for each repo
+# this is used to indicate the repos were built even if it 
+# produces no files in the build area during the scons build
+#
+for REPO in $MUSE_REPOS
+do
+    mkdir -p $MUSE_BUILD_DIR/$REPO
+done
 
 #
 # now run the local build

--- a/bin/museTarball.sh
+++ b/bin/museTarball.sh
@@ -252,17 +252,16 @@ do
     for BUILD in $BUILDS
     do
 	[ $MUSE_VERBOSE -gt 0 ] && echo tar $BUILD/$REPO
+	if [ ! -d $BUILD/$REPO ]; then
+	    echo "ERROR - $BUILD/$REPO does not exist, was it built?"
+	    exit 1
+	fi
 	DD=$( readlink -f $BUILD/$REPO )  # expanded, true dir
 	if [[ "$DD" =~ $cvmfsReg ]]; then
 	    # just save the link
 	    tar $FLAGS $FF $BUILD/$REPO
 	else  
-	    for BD in lib bin gen
-	    do
-		if [ -d $BUILD/$REPO/$BD ]; then
-		    tar $FLAGS $FF $BUILD/$REPO/$BD
-		fi
-	    done
+	    tar $FLAGS $FF --exclude=$BUILD/$REPO/tmp $BUILD/$REPO
 	fi
     done
 done


### PR DESCRIPTION
- make a directory in build area, even if scons does not, 
    so we can tell a build ran and was not simply missing
    - accept this new directory in tarball
- add "muse link HEAD" to get latest CI build
- handle case when "current" is given as an explicit version
- allow "muse setup v10_01_00" to default Musing Offline
- add checks and warnings
- expand linkOrder interpretation to allow more flexible file structure
