### PR TITLE
switch default to 1-path

### DIFF
--- a/bin/museSetup.sh
+++ b/bin/museSetup.sh
@@ -104,7 +104,7 @@ fi
 #
 
 MUSE_QUALS=""
-export MUSE_NPATH=2
+export MUSE_NPATH=1
 
 ARG1=""
 ARG2=""


### PR DESCRIPTION
Two-path allows include statements to have the repo name in the path or not.  Changing the default to one-path will require all code, fcl, and data paths to have the repo name in the include statement. Two path is still available with setup switch "-2".