### PR TITLE
start muse backing command

### DIFF
--- a/bin/mgit
+++ b/bin/mgit
@@ -13,8 +13,8 @@ echo "
    mgit command <args>
 
      A script to help with partial checkout of Offline repo.  It is necessary 
-  to use \"muse link\" to link to the backing build into your Muse working directory.  
-  Then use \"mgit init\" to start the partial checkout area.  Commands \"muse link\"
+  to use \"muse backing\" to link to the backing build into your Muse working directory.  
+  Then use \"mgit init\" to start the partial checkout area.  Commands \"muse backing\"
   and \"mgit init\" must be run while in the Muse working directory, and the other
   mgit commands must be run inside the Offline directory.
      When building only part of a repo locally, it is important to always be 

--- a/bin/muse
+++ b/bin/muse
@@ -21,6 +21,7 @@ museUsage() {
        setup     - setup UPS products and path
        build     - run scons code build
        link      - create a link to a package in another build area
+       backing   - create a link to a backing build in another area
        tarball   - tar up build for grid or a release
 
    To see each actions options, add "-h" to the action
@@ -89,6 +90,12 @@ if [ "$COMMAND" == "setup" ]; then
 elif [ "$COMMAND" == "status" ]; then    
 
     $MUSE_DIR/bin/museStatus.sh "$@"
+    $DONE $?
+
+elif [ "$COMMAND" == "backing" ]; then    
+
+    # this command must be run in the working dir
+    $MUSE_DIR/bin/museBacking.sh "$@"
     $DONE $?
 
 elif [ "$COMMAND" == "link" ]; then    

--- a/bin/museBacking.sh
+++ b/bin/museBacking.sh
@@ -1,0 +1,174 @@
+#! /bin/bash
+#
+# script to drive the muse command to link a package built 
+#  in another area to this area so it be used as input to the build
+#
+
+usageMuseBacking() {
+    cat <<EOF
+
+     muse backing <backing build> <options>
+
+     Create a link to another Muse build area to use it 
+     as backing build for the local build.  The linked area
+     will be included in include, link, fcl and data paths, 
+     but it will not itself be built.
+
+      Since this command is usually run before "muse setup", 
+      in must be run in the intended muse working directory
+
+      If the command is run without any arguments, or with -l, a list
+      of suggested Offline backing builds will be shown
+
+      <backing build>
+           The link selection can be presented various ways
+       1) as a path to a muse working directory:
+           muse backing /mu2e/app/users/\$USER/myBackingBuild
+       2) a branch/commit for a continuous integration backing build:
+           muse backing main/c2409d93
+       3) the latest commit on the main branch from continuous integration
+           muse backing HEAD
+       4) a published Offline tag:
+           muse backing Offline v09_10_00
+               or
+           muse backing Offline (the current verison will be used)
+       5) any other published Musings and tag:
+           muse backing SimJob MDC2020a
+               or
+           muse backing SimJob (where the current verison will be used)
+
+       Note: A backing link is to a Muse working directory and all the repos
+       in that working dir will be available in building and running
+
+       <options>
+       -h, --help  : print usage
+       -r, --rm  : remove existing link
+
+EOF
+  return
+}
+
+
+if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" ]]; then
+    usageMuseBacking
+    exit 0
+fi
+
+if [[ "$1" == "-r" || "$1" == "--rm" ]]; then
+    rm -f backing
+    exit 0
+fi
+
+CI_BASE=/cvmfs/mu2e-development.opensciencegrid.org/museCIBuild
+MUSINGS=/cvmfs/mu2e.opensciencegrid.org/Musings
+
+TARGET="$1"
+VERSION="$2"
+
+#
+# if no target, list cvmfs Offline
+#
+
+if [[ -z "$TARGET" || "$TARGET" == "-l" ]]; then
+
+    echo "  Recent published Offline releases:"
+    CC=$( basename $( readlink -f $MUSINGS/Offline/current ) )
+    ls -1 $MUSINGS/Offline | grep -v current | tail -5 | sed "s/$CC/$CC   (current)/"
+
+    echo "  Recent Offline CI builds"
+    BRANCHES=$( ls $CI_BASE )
+    for BRANCH in $BRANCHES
+    do
+	find $CI_BASE/$BRANCH -mindepth 1 -maxdepth 1  \
+	    -printf "%TY-%Tm-%Td %TH:%TM %p\n" |   \
+	    sort -r | sed 's|'$CI_BASE/'||'
+    done
+
+    exit 0
+fi
+
+
+#
+# check if links are already there
+#
+
+if [ -d link ]; then
+    echo "WARNING - a link directory already exists.  The link function"
+    echo "        overlaps with the backing function.  Once the backing link"
+    echo "        is made, the link dir will be ignored in setup and build."
+    echo "        Or you can run \"muse link -r\"  to remove the links."
+    exit 1
+fi
+if [ -e backing ]; then
+    echo "WARNING - will remove existing backing link:"
+    /bin/ls -l backing | awk '{print "    " $NF}'
+    /bin/rm backing
+fi
+
+
+#
+# try to interpret the target 
+#
+
+pubreg="^v[0-9,_]*+$"
+FTARGET="no_final_target"
+NWORD=$(echo $TARGET | awk -F/ '{print NF}')
+PRINTCURRENT="no"
+
+if [ $MUSE_VERBOSE -gt 0 ]; then
+    echo "TARGET=$TARGET"
+    echo "VERSION=$VERSION"
+    echo "NWORD=$NWORD"
+fi
+
+if [[ "$TARGET" == "HEAD" ||  "$TARGET" == "head" ]]; then
+    LASTHASH=$(ls -1tr $CI_BASE/main | tail -1)
+    FTARGET=$CI_BASE/main/$LASTHASH
+    [ $MUSE_VERBOSE -gt 0 ] &&  \
+        echo "backing will be CI build at main/$LASTHASH"
+
+elif [ -d $CI_BASE/$TARGET ]; then
+    # NWORD=1 so if X is a Musing, you can still link ./X
+    # the target matched a CI build directory
+    FTARGET=$CI_BASE/$TARGET
+    [ $MUSE_VERBOSE -gt 0 ] && echo "backing will be CI build at $TARGET"
+
+elif [[ -d $MUSINGS/$TARGET && $NWORD -eq 1 ]]; then
+    # NWORD=1 so if X is a Musing, you can still link ./X
+    # target matched a Musing
+    # have to use readlink in case version was "current"
+    TV="$VERSION"
+    [ -z "$TV" ] && TV="current"
+    FTARGET=$( readlink -f $MUSINGS/$TARGET/$TV )
+    # readline will return empty string if dir doe snot exist
+    if [ -z "$FTARGET" ]; then
+        echo "ERROR - found target in Musings, but did not match version"
+        exit 1
+    fi
+    [ $MUSE_VERBOSE -gt 0 ] && echo "linking published Musing $TARGET $TV"
+    [ "$TV" == "current" ] && PRINTCURRENT="yes"
+
+elif [ -d "$TARGET" ]; then
+    # the target is a local directory
+    FTARGET=$( readlink -f "$TARGET" )
+    [ $MUSE_VERBOSE -gt 0 ] && echo "linking local directory $TARGET"
+else
+    echo "ERROR - target could not be parsed: $TARGET"
+    exit 1
+fi
+
+if [ "$PRINTCURRENT" == "yes"  ]; then
+    TEMPV=$(echo $FTARGET | awk -F/ '{print $NF}' )
+    echo "    $TARGET \"current\" points to $TEMPV"
+fi
+
+ln -s $FTARGET backing
+
+if [ -n "$MUSE_WORK_DIR" ]; then
+    echo "WARNING - Muse is already setup - changing links changes paths.  "
+    echo "          You will need start a new process and run \"muse setup\" again. "
+fi
+
+exit 0
+
+

--- a/bin/museBuild.sh
+++ b/bin/museBuild.sh
@@ -10,7 +10,8 @@ usageMuseBuild() {
 
      Build the code repos ion the Muse working directory.  
      This is two steps:
-     1) create links to the build products of repos added by "muse link"
+     1) if needed, create links to the build products 
+        of repos added by "muse link"
      2) run scons in the Muse working dir
      The build directory in the Muse working directory can be deleted to 
      effectively remove all build products.  Nothing is written anywhere else.
@@ -47,8 +48,12 @@ echo -n "$(date +'%D %H:%M:%S to ')" > $MUSE_BUILD_DIR/.musebuild
 # make a repo directory in the build area for each repo
 # this is used to indicate the repos were built even if it 
 # produces no files in the build area during the scons build
-#
-for REPO in $MUSE_REPOS
+
+# first remove old links, which may be stale
+rm -f $MUSE_BUILD_DIR/link/*
+
+# this should work for old link style and new backing style
+for REPO in $MUSE_LOCAL_REPOS
 do
     mkdir -p $MUSE_BUILD_DIR/$REPO
 done

--- a/bin/museLink.sh
+++ b/bin/museLink.sh
@@ -40,20 +40,38 @@ usageMuseLink() {
 
        Note: A link is to a repo, not another Muse working directory.
        You cannot link a Musing that is not a single-repo build.  For example,
-       if Musings X contains repos Y and Z, then \"muse link X\" will fail. 
-       if Musing X contains repo X, then \"muse link X\" will suceed.  
+       if Musings X contains repos Y and Z, then "muse link X" will fail. 
+       if Musing X contains repo X, then "muse link X" will suceed.  
        
 
        <options>
        -h, --help  : print usage
+       -r, --rm  : remove existing links
  
 EOF
   return
 }
 
+    cat <<EOF
+
+     ********************************************************
+       Muse is deprecating the "link" function, which links
+       to individual repos, in favor of the new "backing" function,
+       which links to an entre backing build.  This is simpler,
+       more convenient, and less likely to lead to inconsisten buils       
+     ********************************************************
+
+EOF
+
 
 if [[ "$1" == "-h" || "$1" == "--help" || "$1" == "help" ]]; then
     usageMuseLink
+    exit 0
+fi
+
+if [[ "$1" == "-r" || "$1" == "--rm" ]]; then
+    rm -rf link
+    rm -rf build/*/link
     exit 0
 fi
 
@@ -84,6 +102,17 @@ if [[ -z "$TARGET" || "$TARGET" == "-l" ]]; then
 
     exit 0
 fi
+
+#
+# stop if links are already there
+#
+
+if [ -e backing ]; then
+    echo "ERROR - a backing link already exists, this is inconsistent"
+    echo "        with running link, please use backing function or \"rm backing\""
+    exit 1
+fi
+
 
 #
 # try to interpret the target 

--- a/bin/museStatus.sh
+++ b/bin/museStatus.sh
@@ -69,7 +69,14 @@ echo ""
 
 [ $MUSE_VERBOSE -gt 0 ] && echo "directory containing repos to be built:"
 echo "  MUSE_WORK_DIR = $MUSE_WORK_DIR "
-[ $MUSE_VERBOSE -gt 0 ] && echo "space-separated list of local repos to build:"
+if [ -n "$MUSE_BACKING" ]; then
+    for BDIR in $MUSE_BACKING
+    do
+        echo "    backed by $BDIR"
+    done
+fi
+
+[ $MUSE_VERBOSE -gt 0 ] && echo "space-separated list of repos in paths:"
 echo "  MUSE_REPOS = " $MUSE_REPOS
 
 linkReg="^link/*"

--- a/python/sconstruct_helper.py
+++ b/python/sconstruct_helper.py
@@ -72,11 +72,17 @@ def cppPath(mu2eOpts):
     path = []
     # the directory containing the local repos
     path.append(mu2eOpts["workDir"])
-    path.append(mu2eOpts["workDir"]+"/link")
-    # add the build directory of each package, for generated code
-    if os.environ['MUSE_NPATH'] == "2" :
-        for repo in mu2eOpts['repos'].split():
-            path.append(mu2eOpts['workDir']+'/'+repo)
+    # the backing build areas style
+    if len(os.environ['MUSE_BACKING'])>0 :
+        for bdir in os.environ['MUSE_BACKING'].split():
+            path.append(bdir)
+    else:
+        # the linked repo style
+        path.append(mu2eOpts["workDir"]+"/link")
+        # add the build directory of each package, for generated code
+        if os.environ['MUSE_NPATH'] == "2" :
+            for repo in mu2eOpts['repos'].split():
+                path.append(mu2eOpts['workDir']+'/'+repo)
 
     path = path + [
         os.environ['ART_INC'],


### PR DESCRIPTION
- new muse "backing" links to a backing build directory, where "muse link" links to a single backing repo
- muse backing does not support two-path
- remove "muse setup v10_01_00"" option where the Musing defaults to Offline (too complex, ambiguous)
- removed "setup muse" from setup.sh since it duplicates the "setup muse" in "setup mu2e"
- if there are links and no backing, then ru old linking scripts.  If backing exists, or neither, then run backing script
- the old script is "if segregated" in museSetup.sh and museTarball.sh to make it easier to remove later  