### PR TITLE
two new features for KinKal

### DIFF
--- a/bin/museBuild.sh
+++ b/bin/museBuild.sh
@@ -54,6 +54,28 @@ do
 done
 
 #
+# if the user set some scripts to run before building
+#
+if [ "$MUSE_PRESOURCE" ]; then
+    echo "Muse presource: $MUSE_PRESOURCE"
+    source $MUSE_PRESOURCE
+    RC=$?
+    if [ $RC -ne 0 ]; then
+        echo "ERROR - MUSE_PRESOURCE returns $RC"
+        exit $RC
+    fi
+fi
+if [ "$MUSE_PREBUILD" ]; then
+    echo "Muse prebuild: $MUSE_PREBUILD"
+    $MUSE_PREBUILD
+    RC=$?
+    if [ $RC -ne 0 ]; then
+        echo "ERROR - MUSE_PREBUILD returns $RC"
+        exit $RC
+    fi
+fi
+
+#
 # now run the local build
 #
 

--- a/bin/museSetup.sh
+++ b/bin/museSetup.sh
@@ -110,7 +110,7 @@ QFOUND=""
 for ARG in "$@"
 do
     if [ "$QFOUND" == "true" ]; then
-        MUSE_QUALS="$MUSE_QUALS $ARG"
+        [ "$ARG" != "-q" ] && MUSE_QUALS="$MUSE_QUALS $ARG"
     elif [ "$ARG" == "-q" ]; then
         QFOUND="true"
     elif [[  "$ARG" == "-h" || "$ARG" == "--help" || "$ARG" == "help" ]]; then
@@ -305,6 +305,13 @@ if [ $MUSE_VERBOSE -gt 0 ]; then
     done
 fi
 
+#
+# include local UPS products
+#
+if [ -d $MUSE_WORK_DIR/artexternals ]; then
+    echo "INFO - Adding \$MUSE_WORK_DIR/artexternals to UPS PRODUCTS path"
+    export PRODUCTS=$MUSE_WORK_DIR/artexternals:$PRODUCTS
+fi
 
 #
 # figure out what environmental UPS setups to run
@@ -402,7 +409,6 @@ if [ -z "$MUSE_ENVSET"  ]; then
     errorMessage
     return 1
 fi
-
 
 if [ $MUSE_VERBOSE -gt 0 ]; then
     echo "INFO - running environmental set $MUSE_ENVSET "


### PR DESCRIPTION
- allow multiple "-q" in qualifiers
- add $MUSE_WORK_DIR/artexternals to PRODUCTS automatically (with print warning)
- add MUSE_PRESOURCE and MUSE_PREBUILD and commands to be sourced or run before the scons build

This allows KinKal to be built automatically as part of muse build, with changes elsewhere