### PR TITLE
start custom cppflags option

### DIFF
--- a/bin/museStatus.sh
+++ b/bin/museStatus.sh
@@ -110,6 +110,10 @@ if [ "$MUSE_PREBUILD" ]; then
     [ $MUSE_VERBOSE -gt 0 ] && echo "the pre build command:"
     echo "  MUSE_PREBUILD = " $MUSE_PREBUILD
 fi
+if [ "$MUSE_CPPFLAGS" ]; then
+    [ $MUSE_VERBOSE -gt 0 ] && echo "compile flags requested in .muse files:"
+    echo "  MUSE_CPPFLAGS = " $MUSE_CPPFLAGS
+fi
 
 echo
 

--- a/python/sconstruct_helper.py
+++ b/python/sconstruct_helper.py
@@ -143,10 +143,17 @@ def mergeFlags(mu2eOpts):
         if nn >= 27 :
             std = '-std=c++20'
 
+    cppflags = []
+    flagstr = os.environ.get('MUSE_CPPFLAGS')
+    if flagstr :
+        cppflags = flagstr.split()
+
     flags = [std,'-Wall','-Wno-unused-local-typedefs','-g',
              '-Werror','-Werror=pedantic',
              '-Wl,--no-undefined','-gdwarf-2', '-Wl,--as-needed',
-             '-Werror=return-type','-Winit-self','-Woverloaded-virtual' ]
+             '-Werror=return-type','-Winit-self','-Woverloaded-virtual']
+    flags = flags + cppflags
+
     if build == 'prof':
         flags = flags + [ '-O3', '-fno-omit-frame-pointer', '-DNDEBUG' ]
     elif build == 'debug':


### PR DESCRIPTION
The .muse files or the envset can add custom cpp flags to the build command.  This can help with backwards compatibility as code options changes.