### PR TITLE
tweaks for spack

### DIFF
--- a/bin/museDefine.sh
+++ b/bin/museDefine.sh
@@ -1,0 +1,4 @@
+muse ()
+{
+    source ${MUSE_DIR}/bin/muse
+}

--- a/bin/museSetup.sh
+++ b/bin/museSetup.sh
@@ -93,13 +93,6 @@ if [ -n "$MUSE_ERROR" ]; then
     return 1
 fi
 
-if [ -n "$MUSE_WORK_DIR" ]; then
-    echo "ERROR - Muse already setup for directory "
-    echo "               $MUSE_WORK_DIR "
-    echo "               with OPTS: $MUSE_QUALS"
-    return 1
-fi
-
 #
 # parse args
 #
@@ -159,6 +152,16 @@ if [[ "$LCARG" == "ops" || "$LCARG" == "ana" ]]; then
     return $?
 fi
 
+#
+# error quit, if trying to setup a working dir, but already setup
+#
+
+if [ -n "$MUSE_WORK_DIR" ]; then
+    echo "ERROR - Muse already setup for directory "
+    echo "               $MUSE_WORK_DIR "
+    echo "               with OPTS: $MUSE_QUALS"
+    return 1
+fi
 
 #
 # determine the working dir, and MUSE_WORK_DIR


### PR DESCRIPTION
- switch order of running "muse setup ops" and checking for repeated setup. hoping to support running these in either order in the same process, but we'll see
- add museDefine.sh  Currently ups table file sets the "muse" bash function, which is an important part of muse functionality.  spack appears to have the capability to source a file in setup, again we'll see