### PR TITLE
fix path order

### DIFF
--- a/bin/muse
+++ b/bin/muse
@@ -46,7 +46,7 @@ fi
 # checks
 #
 if [ -z "$MU2E" ]; then
-    echo "ERROR - muse was not setup"
+    echo "ERROR - mu2e was not setup"
     $DONE 1
 fi
 

--- a/bin/museSetup.sh
+++ b/bin/museSetup.sh
@@ -77,7 +77,7 @@ mdropit() {
         echo $1
     else
         if [ "$MU2E_SPACK" ]; then
-            echo $1:$2
+            echo $2:$1
         else
             echo $(dropit -p $1 -sfe $2)
         fi


### PR DESCRIPTION
In spack mode, the local locally build bins and libs where being post-pended instead of pre-pended.  As long as there were no accidental name clashes, this would only cause a failure when a locally built Offline had a backing to another Offline.  I think we just haven't had enough use to run into this case yet.